### PR TITLE
User commands and loading config file

### DIFF
--- a/proton/src/config.rs
+++ b/proton/src/config.rs
@@ -1,6 +1,6 @@
 use rustc_serialize::json;
 use std::fs::File;
-use std::io::Write;
+use std::io::{self, Read, Write};
 use std::path::Path;
 
 #[derive(RustcEncodable, RustcDecodable)]
@@ -11,13 +11,23 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(config_path: String) -> Config {
+    fn new(config_path: String) -> Config {
         Config {
             cfg_path: config_path,
             key: "key.pem".to_string(),
             vixen_folder: Path::new("/home/ryan/Dropbox/Great Northern Sequencing/Sequencing/Sequence Data")
                 .to_str().expect("Vixen folder path not valid unicode").to_owned(),
         }
+    }
+
+    // Loads config from file. If not found, creates new config at specified path
+    //#TODO: clean up, make more error-friendly
+    pub fn load(config_path: String) -> Config {
+        let mut file = File::open(config_path).unwrap();
+        let mut string = String::new();
+        file.read_to_string(&mut string);
+        let config: Config = json::decode(&string).unwrap();
+        config
     }
 
     // Saves config to file

--- a/proton/src/docopt_args.rs
+++ b/proton/src/docopt_args.rs
@@ -29,7 +29,7 @@ Usage:
   proton permissions list
   proton user add <user-name>
   proton user delete <user-name>
-  proton user get <user-name>
+  proton user get <user-key>
   proton run update
   proton run repl
   proton run show
@@ -51,6 +51,7 @@ pub struct DocoptArgs {
   pub arg_secid: Option<u32>,
   pub arg_seqid: Option<u32>,
   pub arg_user_name: Option<String>,
+  pub arg_user_key: Option<String>,
 
   pub flag_audio: Option<String>,
   pub flag_data_file: Option<String>,

--- a/proton/src/handlers/project.rs
+++ b/proton/src/handlers/project.rs
@@ -1,7 +1,5 @@
 use docopt_args::DocoptArgs;
 use ProtonConfig;
-use std::fs::File;
-use std::io::Write;
 use util;
 
 /// Handles all "proton project ..." commands
@@ -29,12 +27,8 @@ pub fn project_new(args: DocoptArgs, mut config: ProtonConfig) {
     // Save admin key to file if successful
     if output.is_some() {
         let key = output.unwrap();
-
-        // new-project returns an SSH key, which starts with a bunch of dashes
-        let key_start = key.find("-").expect("Invalid output from proton_cli");
         let file_name = format!("{}.pub", project_name);
-        let mut out_file = File::create(&file_name).expect("Failed to create key file");
-        out_file.write(&key.into_bytes()[key_start..]);
+        util::write_key_to_file(key, &file_name);
 
         // Also add to config
         config.key = file_name;

--- a/proton/src/handlers/user.rs
+++ b/proton/src/handlers/user.rs
@@ -1,6 +1,67 @@
 use docopt_args::DocoptArgs;
 use ProtonConfig;
+use util;
+use std::fs;
+
 
 pub fn handle_user(args: DocoptArgs, config: ProtonConfig) {
-    println!("handle-user");
+    if args.cmd_add.unwrap_or(false) {
+        user_add(args, config)
+    } else if args.cmd_delete.unwrap_or(false) {
+        user_delete(args, config)
+    } else if args.cmd_get.unwrap_or(false) {
+        user_get(args, config)
+    } else {
+        panic!("Docopt parsing failed!")
+    }
+}
+
+// proton user add <user-name>
+fn user_add(args: DocoptArgs, config: ProtonConfig) {
+    let command = "./proton_cli new-user <admin-key> <name>";
+    let user_name = args.arg_user_name.unwrap();
+    let args = [
+        "new-user".to_string(),
+        config.key,
+        user_name.clone()];
+
+    let output = util::run_proton_cli(command, &args);
+
+    // Save user key to file if successful
+    if output.is_some() {
+        let key = output.unwrap();
+        let file_name = format!("{}.pub", user_name.replace(" ", ""));
+        util::write_key_to_file(key, &file_name);
+
+        // Tell the user where their key file is
+        println!("User creation successful. Key saved to {}. DO NOT share this key!", file_name);
+    }
+}
+// proton user delete <user-name>
+fn user_delete(args: DocoptArgs, config: ProtonConfig) {
+    let command = "./proton_cli remove-user <admin-key> <name>";
+    let user_name = args.arg_user_name.unwrap();
+    let args = [
+        "remove-user".to_string(),
+        config.key,
+        user_name.clone()];
+
+    let output = util::run_proton_cli(command, &args);
+
+    // Delete key file if command successful
+    if output.is_some() {
+        let file_name = format!("{}.pub", user_name.replace(" ", ""));
+        fs::remove_file(&file_name).expect("Failed to remove user key file");
+    }
+}
+
+// Eventually: proton user get <user-name>
+// Now: proton user get <user-key>
+fn user_get(args: DocoptArgs, config: ProtonConfig) {
+    let command = "./proton_cli get-user <public-key>";
+    let args = [
+        "get-user".to_string(),
+        args.arg_user_key.unwrap()];
+
+    let _ = util::run_proton_cli(command, &args);
 }

--- a/proton/src/main.rs
+++ b/proton/src/main.rs
@@ -9,7 +9,7 @@ use docopt::Docopt;
 
 fn main() {
   // Load configuration file
-  let config = ProtonConfig::new("proton.cfg".to_string());
+  let config = ProtonConfig::load("proton.cfg".to_string());
 
   // Get command line arguments using Docopt. Provides guarantees about input types.
   let args: DocoptArgs = Docopt::new(protonlib::USAGE)

--- a/proton/src/util.rs
+++ b/proton/src/util.rs
@@ -1,5 +1,8 @@
+use std::fs::File;
+use std::io::Write;
 use std::process::{Command, Output};
 
+/// Runs proton_cli with the given command and arguments
 pub fn run_proton_cli(command: &str, args: &[String]) -> Option<String> {
     let output = Command::new("proton_cli")
         .args(args)
@@ -9,6 +12,7 @@ pub fn run_proton_cli(command: &str, args: &[String]) -> Option<String> {
     handle_output(output)
 }
 
+/// Runs proton_vixen_converter.py with the given command and arguments
 pub fn run_vixen_converter(command: &str, args: &[String]) -> Option<String> {
     let output = Command::new("python3")
         .arg("../proton-vixen-converter/vixenconverter/converter.py")
@@ -35,4 +39,14 @@ fn handle_output(output: Output) -> Option<String> {
     // Also print output for fun
     println!("{}", out);
     Some(out)
+}
+
+/// Writes an SSH key output to a file
+pub fn write_key_to_file(key: String, file_name: &str) {
+    // When handle_output returns an SSH key, it starts with a bunch of dashes
+    let key_start = key.find("-").expect("Invalid output from proton_cli");
+
+    // Write key
+    let mut out_file = File::create(&file_name).expect("Failed to create key file");
+    let _ = out_file.write(&key.into_bytes()[key_start..]);
 }


### PR DESCRIPTION
Completes #3. Requires proton_cli commit a87f862d9a9539ac342a918fb79c721ae8d12737 on branch meta_changes (latest commit as of this post). Checkout this commit, then run `cargo install --force` to use it.